### PR TITLE
Add shader core mask reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The query mechanism can report the following information about the GPU:
 * **Architecture:** The product architecture name string, e.g. "Valhall".
 * **Model number:** The product ID number, e.g. 0xa002.
 * **Shader core count:** The number of shader cores in the design.
+* **Shader core mask:** The shader core topology mask.
 * **L2 cache count:** The number of L2 cache slices in the design.
 * **L2 cache size:** The total L2 cache size, summed over all slices, in bytes.
 * **Bus size:** The width of the external data bus, per cache slice, in bits.

--- a/source/arm_gpuinfo.cpp
+++ b/source/arm_gpuinfo.cpp
@@ -120,6 +120,7 @@ int main(int argc, char *argv[])
     std::cout << "  Architecture: " << info.architecture_name << "\n";
     std::cout << "  Model number: 0x" << std::hex << info.gpu_id << std::dec << "\n";
     std::cout << "  Core count: " << info.num_shader_cores << "\n";
+    std::cout << "  Core mask: 0x" << std::hex << info.shader_core_mask << std::dec << "\n";
     std::cout << "  L2 cache count: " << info.num_l2_slices << "\n";
     std::cout << "  Total L2 cache size: " << info.num_l2_bytes << " bytes\n";
     std::cout << "  Bus width: " << info.num_bus_bits << " bits\n";

--- a/source/libgpuinfo.hpp
+++ b/source/libgpuinfo.hpp
@@ -79,6 +79,9 @@ struct gpuinfo
     /** Number of shader cores */
     uint32_t num_shader_cores;
 
+    /** Shader core topology mask */
+    uint64_t shader_core_mask;
+
     /** Number of L2 cache slices */
     uint32_t num_l2_slices;
 


### PR DESCRIPTION
This PR adds support for reporting the shader core mask, which is primarily useful information for remote support cases when we don't have physical access to a device. 