### PR TITLE
Add arch major/minor info

### DIFF
--- a/android_build.sh
+++ b/android_build.sh
@@ -31,7 +31,7 @@ pushd ${BUILD_DIR_64}
 cmake \
     -DCMAKE_SYSTEM_NAME=Android \
     -DANDROID_PLATFORM=29 \
-    -DANDROID_ABI=arm64-v8a \
+    -DANDROID_ABI=armeabi-v7a \
     -DANDROID_TOOLCHAIN=clang \
     -DANDROID_STL=c++_static \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \

--- a/android_build.sh
+++ b/android_build.sh
@@ -31,7 +31,7 @@ pushd ${BUILD_DIR_64}
 cmake \
     -DCMAKE_SYSTEM_NAME=Android \
     -DANDROID_PLATFORM=29 \
-    -DANDROID_ABI=armeabi-v7a \
+    -DANDROID_ABI=arm64-v8a \
     -DANDROID_TOOLCHAIN=clang \
     -DANDROID_STL=c++_static \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \

--- a/source/arm_gpuinfo.cpp
+++ b/source/arm_gpuinfo.cpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2023 ARM Limited.
+ * Copyright (c) 2023-2024 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -119,6 +119,8 @@ int main(int argc, char *argv[])
     std::cout << "GPU configuration:\n";
     std::cout << "  Name: " << info.gpu_name << "\n";
     std::cout << "  Architecture: " << info.architecture_name << "\n";
+    std::cout << "  Architecture version: " << info.architecture_major
+              << "." << info.architecture_minor <<"\n";
     std::cout << "  Model number: 0x" << std::hex << info.gpu_id << std::dec << "\n";
     std::cout << "  Core count: " << info.num_shader_cores << "\n";
     std::cout << "  Core mask: 0x" << std::hex << info.shader_core_mask << std::dec << "\n";

--- a/source/libgpuinfo.cpp
+++ b/source/libgpuinfo.cpp
@@ -1151,8 +1151,9 @@ bool instance::init_props_pre_r21() {
     info_.num_l2_slices = props.props.l2_props.num_l2_slices;
     info_.num_bus_bits = 1UL << (props.props.raw_props.l2_features >> 24);
 
-    // Old core must have 32-bit GPU ID
+    // Old kernel driver must have 32-bit GPU ID
     switch (info_.gpu_id) {
+        // Midgard GPUs require manual specification, as not machine readable
         case 0x6956: // Mali-T600
             info_.architecture_major = 4;
             info_.architecture_minor = 0;
@@ -1179,6 +1180,7 @@ bool instance::init_props_pre_r21() {
             info_.architecture_major = 5;
             info_.architecture_minor = 2;
             break;
+        // Bifrost onwards report architecture version via config register
         default:
         {
             uint32_t raw_gpu_id = props.props.raw_props.gpu_id;

--- a/source/libgpuinfo.cpp
+++ b/source/libgpuinfo.cpp
@@ -1156,9 +1156,9 @@ bool instance::init_props_pre_r21() {
     uint32_t raw_gpu_id = props.props.raw_props.gpu_id;
     constexpr unsigned int arch_major_offset { 28 };
     constexpr unsigned int arch_minor_offset { 24 };
-    constexpr unsigned int nibble { 0xF };
-    info_.architecture_major = (raw_gpu_id >> arch_major_offset) & nibble;
-    info_.architecture_minor = (raw_gpu_id >> arch_minor_offset) & nibble;
+    constexpr unsigned int bits4 { 0xF };
+    info_.architecture_major = (raw_gpu_id >> arch_major_offset) & bits4;
+    info_.architecture_minor = (raw_gpu_id >> arch_minor_offset) & bits4;
 
     info_.gpu_id = props.props.core_props.product_id;
     info_.num_l2_bytes = 1UL << props.props.l2_props.log2_cache_size;

--- a/source/libgpuinfo.hpp
+++ b/source/libgpuinfo.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023 ARM Limited.
+ * Copyright (c) 2021-2024 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -64,7 +64,7 @@
 
 namespace libarmgpuinfo {
 
-/** Mali GPU information. */
+/** Arm GPU information. */
 struct gpuinfo
 {
     /** GPU name */
@@ -75,6 +75,12 @@ struct gpuinfo
 
     /** GPU ID */
     uint32_t gpu_id;
+
+    /** GPU architecture major version */
+    uint32_t architecture_major;
+
+    /** GPU architecture minor version */
+    uint32_t architecture_minor;
 
     /** Number of shader cores */
     uint32_t num_shader_cores;


### PR DESCRIPTION
Add support for reporting architecture major/minor versions to help provide some means to tell how new (from an architecture point of view) an unknown GPU is. 

Fixes #6 