### PR TITLE
Disable CMake deprecation warnings in Android NDK

### DIFF
--- a/android_build.sh
+++ b/android_build.sh
@@ -52,6 +52,7 @@ cmake \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
     -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
     -DCMAKE_INSTALL_PREFIX=../ \
+    -DCMAKE_WARN_DEPRECATED=OFF \
     ..
 
 make install -j8


### PR DESCRIPTION
Current NDK toolchain file always triggers these,
so we can't fix them in the project wrapper.