### PR TITLE
Update GitHub Actions (Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/android-clang.yaml
+++ b/.github/workflows/android-clang.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up JDK 21 environment
       run: |
@@ -32,7 +32,7 @@ jobs:
         make
 
     - name: Upload binaries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: libgpu-linux-x86
         path: |

--- a/.github/workflows/linux-clang.yaml
+++ b/.github/workflows/linux-clang.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build with Clang
       run: |
@@ -22,7 +22,7 @@ jobs:
         make
 
     - name: Upload binaries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: libgpu-linux-x86
         path: |

--- a/.github/workflows/linux-gcc.yaml
+++ b/.github/workflows/linux-gcc.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Git checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Build with GCC
       run: |
@@ -22,7 +22,7 @@ jobs:
         make
 
     - name: Upload binaries
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: libgpu-linux-x86
         path: |


### PR DESCRIPTION
This is to update from Node.js 20 to Node.js 24, as [GitHub has deprecated support and will remove Node.js 20 later this year](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).